### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-type-animation": "^3.2.0"
+    "react-type-animation": "^3.2.0",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/components/StatusFeed.tsx
+++ b/src/components/StatusFeed.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { AlertCircle, CheckCircle, Clock, Wifi, WifiOff } from 'lucide-react';
+import sanitizeHtml from 'sanitize-html';
 
 interface StatusEvent {
   title: string;
@@ -212,7 +213,7 @@ export const StatusFeed: React.FC<StatusFeedProps> = ({ maxEvents = 3 }) => {
                     </h4>
                     {event.description && (
                       <p className="text-gray-400 text-xs mb-2 line-clamp-2">
-                        {event.description.replace(/<[^>]*>/g, '').substring(0, 100)}
+                        {sanitizeHtml(event.description || '', { allowedTags: [], allowedAttributes: {} }).substring(0, 100)}
                         {event.description.length > 100 ? '...' : ''}
                       </p>
                     )}


### PR DESCRIPTION
Potential fix for [https://github.com/anir0y/anir0y.github.io/security/code-scanning/2](https://github.com/anir0y/anir0y.github.io/security/code-scanning/2)

The optimal way to fix this sanitization problem is to use a well-tested HTML sanitization library, such as `sanitize-html`, to safely strip out all HTML tags, script tags, and attributes that could cause injection. If external libraries are not permitted, an alternative is to repeatedly apply the `.replace()` until no further replacements occur, but this still risks edge cases. Using `sanitize-html` is both simpler and more robust.

具体地，修改发生在 `src/components/StatusFeed.tsx`：  
- Add an import for `sanitize-html` at the top of the file.  
- Use `sanitizeHtml(event.description, { allowedTags: [], allowedAttributes: {} })`, which strips all tags and attributes, instead of the `.replace(/<[^>]*>/g, '')` regex.  
- Optionally, fallback to returning an empty string if `event.description` is undefined or null.  
- No changes to displayed logic (keep truncation after 100 characters and ellipsis).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
