### PR TITLE
Mobile polish + fix vite@8 install (plugin-react ^5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ secret.conf.bak.*
 # Local Netlify folder
 .netlify
 .ogbuild
+
+# Claude Code session runtime state
+.claude/scheduled_tasks.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@types/three": "^0.169.0",
-        "@vitejs/plugin-react": "^4.3.3",
+        "@vitejs/plugin-react": "^5.0.0",
         "jsdom": "^25.0.1",
         "typescript": "^5.6.3",
         "vite": "^8.0.14",
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -973,24 +973,24 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.18.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2328,9 +2328,9 @@
       "peer": true
     },
     "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/three": "^0.169.0",
-    "@vitejs/plugin-react": "^4.3.3",
+    "@vitejs/plugin-react": "^5.0.0",
     "jsdom": "^25.0.1",
     "typescript": "^5.6.3",
     "vite": "^8.0.14",

--- a/src/index.css
+++ b/src/index.css
@@ -73,7 +73,7 @@ nav.links a.active::before{content:"";position:absolute;left:12px;right:12px;bot
 .nav-status{display:flex;align-items:center;gap:8px;font-family:var(--font-mono);font-size:10px;color:var(--green);letter-spacing:1px}
 .nav-status .pip{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 9px var(--green);animation:pip 1.6s infinite}
 @keyframes pip{50%{opacity:.3}}
-.burger{display:none;background:none;border:1px solid var(--panel-line);border-radius:8px;color:var(--cyan);width:42px;height:38px;cursor:pointer;font-size:16px}
+.burger{display:none;background:none;border:1px solid var(--panel-line);border-radius:8px;color:var(--cyan);width:44px;height:44px;cursor:pointer;font-size:16px}
 @media (max-width:880px){
   nav.links{position:fixed;inset:64px 0 auto 0;flex-direction:column;gap:0;background:rgba(5,7,10,.96);backdrop-filter:blur(16px);border-bottom:1px solid var(--panel-line);padding:10px;transform:translateY(-140%);transition:.45s var(--ease)}
   nav.links.open{transform:translateY(0)} nav.links a{padding:14px;font-size:13px;width:100%}
@@ -104,7 +104,7 @@ h2.title em{font-style:normal;color:var(--cyan);text-shadow:0 0 28px rgba(0,229,
 @media (prefers-reduced-motion:reduce){.glitch-on .glitch{animation:none}}
 
 /* ── Hero ─────────────────────────────────────────────────── */
-#hero{min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding-top:120px}
+#hero{min-height:100vh;min-height:100svh;display:flex;flex-direction:column;justify-content:center;padding-top:120px}
 .hero-tag{font-family:var(--font-mono);font-size:12px;letter-spacing:4px;text-transform:uppercase;color:var(--cyan-dim);margin-bottom:24px;display:flex;align-items:center;gap:12px}
 .hero-tag::before{content:"◢";color:var(--orange)}
 .hero h1{font-family:var(--font-title);font-size:clamp(38px,7.4vw,92px);font-weight:700;line-height:1.0;letter-spacing:-.5px;text-transform:uppercase}
@@ -297,3 +297,14 @@ footer{border-top:1px solid var(--panel-line);padding:40px 0 48px;position:relat
 .skip:focus{left:0}
 ::-webkit-scrollbar{width:10px;height:10px}::-webkit-scrollbar-track{background:var(--obsidian)}
 ::-webkit-scrollbar-thumb{background:#16222e;border-radius:6px;border:2px solid var(--obsidian)}::-webkit-scrollbar-thumb:hover{background:#1d3140}
+
+/* ── Touch / small-screen polish ──────────────────────────── */
+/* Kill the iOS grey tap flash and the 300ms click delay on controls. */
+a,button,.btn,.pill,.chip,.node,a.intel,a.lab,.cmdk-item,.social a,.burger{-webkit-tap-highlight-color:transparent;touch-action:manipulation}
+@media (max-width:560px){
+  /* Trim the generous desktop vertical rhythm so phones aren't all whitespace. */
+  section{padding:clamp(64px,9vh,110px) 0}
+  #hero{padding-top:96px}
+  .hero-cta .btn{flex:1 1 auto;justify-content:center}  /* full-width, thumb-friendly CTAs */
+  .hero-readout{gap:8px 18px}
+}

--- a/src/three/scene.ts
+++ b/src/three/scene.ts
@@ -9,6 +9,9 @@ import * as THREE from "three";
 export function initScene(canvas: HTMLCanvasElement): () => void {
   const REDUCED = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
   const MOBILE = window.matchMedia?.("(max-width: 760px)").matches ?? false;
+  // Track last applied viewport so we can ignore mobile URL-bar show/hide,
+  // which fires resize with a height-only change and otherwise causes jank.
+  let lastW = window.innerWidth, lastH = window.innerHeight;
 
   const renderer = new THREE.WebGLRenderer({
     canvas, antialias: !MOBILE, alpha: true, powerPreference: "high-performance",
@@ -163,8 +166,13 @@ export function initScene(canvas: HTMLCanvasElement): () => void {
   const onPointer = (e: PointerEvent) => { pointer.tx = e.clientX / window.innerWidth - 0.5; pointer.ty = e.clientY / window.innerHeight - 0.5; };
   const onScroll = () => { const max = document.documentElement.scrollHeight - window.innerHeight; scrollP = max > 0 ? Math.min(1, Math.max(0, window.scrollY / max)) : 0; };
   const onResize = () => {
-    camera.aspect = window.innerWidth / window.innerHeight; camera.updateProjectionMatrix();
-    renderer.setSize(window.innerWidth, window.innerHeight);
+    const w = window.innerWidth, h = window.innerHeight;
+    // Skip pure URL-bar collapse on mobile (width unchanged, small height delta):
+    // re-rendering on every scroll-driven toolbar toggle is the main mobile jank.
+    if (w === lastW && Math.abs(h - lastH) < 120) return;
+    lastW = w; lastH = h;
+    camera.aspect = w / h; camera.updateProjectionMatrix();
+    renderer.setSize(w, h);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, MOBILE ? 1.5 : 2));
   };
   window.addEventListener("pointermove", onPointer, { passive: true });


### PR DESCRIPTION
## Mobile-friendliness pass (+ unblock vite@8)

**Mobile fixes** (verified on vite@8):
- Hero uses `100svh` so it isn't clipped under mobile browser chrome.
- `scene.ts` `onResize` ignores the mobile URL-bar show/hide (width unchanged + small height delta) — removes WebGL re-render jank on scroll.
- Burger tap target → 44×44; `-webkit-tap-highlight-color:transparent` + `touch-action:manipulation`; ≤560px tightens section/hero spacing and makes hero CTAs full-width.

**Toolchain fix:** Dependabot (PR #36) bumped `main` to vite@8/vitest@4 but left `@vitejs/plugin-react` at `^4.3.3`, which only peers vite ≤7 — so `main` was **not installable** (`npm install` ERESOLVE). This bumps `@vitejs/plugin-react ^4.3.3 → ^5.0.0` (adds vite ^8 support).

**Verified:** `npm install` clean, `vite v8.0.14` build green, **23/23** vitest tests pass.

Also keeps `.claude/scheduled_tasks.lock` untracked (session runtime state).

Supersedes #37 (which was based on pre-vite@8 main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)